### PR TITLE
userコントローラー(destroy)の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,17 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    if @user.destroy
+      flash[:notice] = '削除しました'
+      redirect_to '/users'
+    else
+      flash.now[:alert] = '削除に失敗しました'
+      redirect_to '/users'
+    end
+  end  
+
   private
   
   def user_params
@@ -32,5 +43,3 @@ class UsersController < ApplicationController
     # 結果として、user内にあるemailとpasswordだけを取得
   end
 end
-
-

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,6 +5,7 @@
 <% @users.each do |user| %>
   <h3>ユーザー名</h3>
   <span><%= user.email %></span>
+  <%= button_to "ユーザー削除", user_path(user.id), method: :delete %>
 <% end %>
 
 <div class="text-notice">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  resources :users, only: [:index, :new, :create, :show]
+  resources :users, only: [:index, :new, :create, :show, :destroy]
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe UsersController, type: :request do
         }.to change(User, :count).by(-1)
       end
     end
+    
     context '存在しないユーザーを削除する場合' do
       it 'ユーザー削除に失敗すること' do
         expect{

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -54,10 +54,17 @@ RSpec.describe UsersController, type: :request do
   describe 'DELETE /users' do
     context '存在するユーザーを削除する場合' do
       let!(:user) { create(:user) }
-      it 'ユーザーが削除されること' do
+      it 'ユーザー削除に成功すること' do
         expect{
           delete user_path(user.id)
         }.to change(User, :count).by(-1)
+      end
+    end
+    context '存在しないユーザーを削除する場合' do
+      it 'ユーザー削除に失敗すること' do
+        expect{
+          delete user_path(0)
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -50,4 +50,15 @@ RSpec.describe UsersController, type: :request do
       end
     end
   end
+
+  describe 'DELETE /users' do
+    context '存在するユーザーを削除する場合' do
+      let!(:user) { create(:user) }
+      it 'ユーザーが削除されること' do
+        expect{
+          delete user_path(user.id)
+        }.to change(User, :count).by(-1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
UsersControllerの実装
  - destroyアクション
 
view(ユーザー一覧画面）
  - ユーザー削除ボタンを追加

## 関連Issue
- https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/6

## 動作確認結果

https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/assets/90958196/9a922f47-35c5-4312-ac7e-f2102e1384c4