### PR TITLE
userコントローラー(Update)の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,22 @@ class UsersController < ApplicationController
       flash.now[:alert] = '削除に失敗しました'
       redirect_to '/users'
     end
-  end  
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      flash[:notice] = '変更に成功しました'
+      redirect_to '/users'
+    else
+      flash.now[:alert] = '変更に失敗しました'
+      render :edit
+    end
+  end
 
   private
   

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,29 @@
+<h1>プロフィール編集</h1>
+
+<%= form_with model: @user, url: user_path, local: true, data: { turbo: "false" } do |form| %>
+
+  <div>
+    <h3>
+      <%= flash[:alert] %> 
+    </h3>
+      <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+
+  <table>
+    <tr>
+      <th>メールアドレス</th>
+      <td><%= form.text_field :email %></td>
+    </tr>
+    <tr>
+      <th>パスワード</th>
+      <td><%= form.text_field :password %></td>
+    </tr>
+    <tr>
+      <td><%= form.submit '変更' %></td>
+    </tr>
+  </table>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,3 +6,4 @@
 <p><%= @user.created_at %></p>
 <h3>アカウント更新日</h3>
 <p><%= @user.updated_at %></p>
+<%= button_to "ユーザー編集", edit_user_path(@user.id), method: :get %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  resources :users, only: [:index, :new, :create, :show, :destroy]
+  resources :users, only: [:index, :new, :create, :show, :destroy, :edit, :update]
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -69,4 +69,25 @@ RSpec.describe UsersController, type: :request do
       end
     end
   end
+
+  describe 'PUT /users' do
+    context 'プロフィールの変更が正常に実行された場合' do
+      let!(:user) { create(:user) }
+      it 'プロフィールの変更に成功すること' do
+        put user_path(user.id), params: { user: { email: 'new_sample@example.com', password: 'new_sample_password' } }
+        expect(user.reload.email).to eq 'new_sample@example.com'
+        expect(user.reload.password).to eq 'new_sample_password'
+      end
+    end
+    
+    context 'プロフィールの変更に失敗し、バリデーションエラーとなる場合' do
+      let!(:user) { create(:user) }
+      it 'プロフィールの変更に失敗すること' do
+        put user_path(user.id), params: { user: { email: '', password: '' } }
+        expect(user.reload.email).to eq 'sample@example.com'
+        expect(user.reload.password).to eq 'sample_password'
+        expect(response.body).to include '変更に失敗しました'
+      end
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -74,19 +74,23 @@ RSpec.describe UsersController, type: :request do
     context 'プロフィールの変更が正常に実行された場合' do
       let!(:user) { create(:user) }
       it 'プロフィールの変更に成功すること' do
-        put user_path(user.id), params: { user: { email: 'new_sample@example.com', password: 'new_sample_password' } }
-        expect(user.reload.email).to eq 'new_sample@example.com'
-        expect(user.reload.password).to eq 'new_sample_password'
+        aggregate_failures do
+          put user_path(user.id), params: { user: { email: 'new_sample@example.com', password: 'new_sample_password' } }
+          expect(user.reload.email).to eq 'new_sample@example.com'
+          expect(user.reload.password).to eq 'new_sample_password'
+        end
       end
     end
     
     context 'プロフィールの変更に失敗し、バリデーションエラーとなる場合' do
       let!(:user) { create(:user) }
       it 'プロフィールの変更に失敗すること' do
-        put user_path(user.id), params: { user: { email: '', password: '' } }
-        expect(user.reload.email).to eq 'sample@example.com'
-        expect(user.reload.password).to eq 'sample_password'
-        expect(response.body).to include '変更に失敗しました'
+        aggregate_failures do
+          put user_path(user.id), params: { user: { email: '', password: '' } }
+          expect(user.reload.email).to eq 'sample@example.com'
+          expect(user.reload.password).to eq 'sample_password'
+          expect(response.body).to include '変更に失敗しました'
+        end
       end
     end
   end


### PR DESCRIPTION
## 概要
UsersControllerの実装
  - editアクション
  - updateアクション
 
view
  - マイページに編集ボタンを追加
  - プロフィール編集画面を実装


## 関連Issue
- https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/5

## 動作確認結果

https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/assets/90958196/ad3022f8-789c-4ffb-9265-65a1d1aa9c60


