### PR TITLE
Tweetsモデルの実装

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Tweet < ApplicationRecord
-  validates :user_id, presence: true
+  validates :user, presence: true
   validates :tweet_content, presence: true
 
   belongs_to :user # アソシエーション

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,7 +2,7 @@
 
 class Tweet < ApplicationRecord
   validates :user_id, presence: true
-  validates :body, presence: true
+  validates :tweet_content, presence: true
 
   belongs_to :user # アソシエーション
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Tweet < ApplicationRecord
+  validates :user_id, presence: true
+  validates :body, presence: true
+
+  belongs_to :user # アソシエーション
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,5 @@ class User < ApplicationRecord
   validates :email, presence: true
   validates :password, presence: true
 
-  has_many :tweets # アソシエーション
+  has_many :tweets
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   validates :email, presence: true
   validates :password, presence: true
+
+  has_many :tweets # アソシエーション
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,8 @@ ja:
       user:
         email: メールアドレス
         password: パスワード
+      tweet:
+        tweet_content: ツイート
     errors:
       messages:
         blank: を入力してください

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,4 +17,10 @@ ActiveRecord::Schema[7.0].define(version: 0) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+  create_table "tweets", charset: "utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 0) do
   end
   create_table "tweets", charset: "utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "body", null: false
+    t.string "tweet_content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,3 +2,5 @@
 
 User.create(email:'kaito@example.com', password:'hogehoge')
 User.create(email:'shoichi@example.com', password:'hohogege')
+
+Tweet.create(user_id:'1', body:'Hello World')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,4 +3,4 @@
 User.create(email:'kaito@example.com', password:'hogehoge')
 User.create(email:'shoichi@example.com', password:'hohogege')
 
-Tweet.create(user_id:'1', body:'Hello World')
+Tweet.create(user_id:'1', tweet_content:'Hello World')

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tweet do
+    tweet_content { 'sample_contet' }
+    # association :user, factory: :user
+    # association :user
+  end
+end

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -3,7 +3,5 @@
 FactoryBot.define do
   factory :tweet do
     tweet_content { 'sample_contet' }
-    # association :user, factory: :user
-    # association :user
   end
 end

--- a/spec/models/tweet_valid_spec.rb
+++ b/spec/models/tweet_valid_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Tweet do
+  describe 'バリデーションのテスト' do
+    context 'tweet_contetが存在する場合' do
+      let(:user) { create(:user) }
+      let(:tweet) { build(:tweet, user_id: user.id)}
+      
+      it 'valid?がtrueになる' do
+        expect(tweet.valid?).to eq true
+      end
+    end
+
+    context 'tweet_contentが空文字の場合' do
+      let(:user) { create(:user) }
+      let(:tweet) { build(:tweet, tweet_content: '', user_id: user.id) }
+
+      it 'valid?がfalseになり、errorsに「ツイートを入力してください」と格納される' do
+        aggregate_failures do
+          result = tweet.valid?
+
+          expect(result).to eq false
+          expect(tweet.errors.full_messages).to eq ['ツイートを入力してください']
+        end
+      end
+    end
+
+    context 'tweet_contentがnilの場合' do
+      let(:user) { create(:user) }
+      let(:tweet) { build(:tweet, tweet_content: nil, user_id: user.id) }
+
+      it 'valid?がfalseになり、errorsに「ツイートを入力してください」と格納される' do
+        aggregate_failures do
+          result = tweet.valid?
+          expect(result).to eq false
+          expect(tweet.errors.full_messages).to eq ['ツイートを入力してください']
+        end
+      end
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Userモデルとの関係' do     
+      it '1:Nの関係になっていること' do
+        association = described_class.reflect_on_association(:user)
+        expect(association.macro).to eq(:belongs_to)
+      end
+    end
+  end
+end

--- a/spec/models/tweet_valid_spec.rb
+++ b/spec/models/tweet_valid_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Tweet do
       it 'valid?がfalseになり、errorsに「ツイートを入力してください」と格納される' do
         aggregate_failures do
           result = tweet.valid?
-
           expect(result).to eq false
           expect(tweet.errors.full_messages).to eq ['ツイートを入力してください']
         end

--- a/spec/models/user_valid_spec.rb
+++ b/spec/models/user_valid_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe User do
-  describe '#presenseメソッド' do
+  describe 'バリデーションのテスト' do
     context 'emailが存在する場合' do
       let(:user) { build(:user, email: 'hoge@example.com') }
 
@@ -61,6 +61,15 @@ RSpec.describe User do
           expect(result).to eq false
           expect(user.errors.full_messages).to eq ['パスワードを入力してください']
         end
+      end
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Tweetモデルとの関係' do
+      it '1:Nとなっている' do
+        association = described_class.reflect_on_association(:tweets)
+        expect(association.macro).to eq(:has_many)
       end
     end
   end


### PR DESCRIPTION
## 概要
- tweetsテーブルの実装（db/schema.rb）
- 初期データの設定(db/seeds.rb)
- Tweetモデルの実装(app/models/tweet.rb)
- UserモデルとTweetモデルにアソシエーションを設定

## 関連Issue
- https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/32

