### PR TITLE
CSSフレームワークbulmaの導入&共通のヘッダーとタブを作成する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
@@ -290,6 +292,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  layout 'header'
+  
   def new; end
 
   def create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   layout 'header'
-  
+
   def new; end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,7 @@ class UsersController < ApplicationController
   # GET /users/new
   def new
     @user = User.new
+    render :layout => 'header'
   end
 
   # POST /users

--- a/app/views/layouts/header.html.erb
+++ b/app/views/layouts/header.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Tubuyaki</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
@@ -10,8 +11,6 @@
     <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-
-  <body>
     <header class="navbar" style="background-color: #a7c957">
       <div class="navbar-brand">
         <span class="navbar-item is-size-3" style="color: #386641">
@@ -19,17 +18,6 @@
         </span>
       </div>
     </header>
-
-    <div class="tabs is-small" style="background-color: #f2e8cf">
-      <ul>
-        <li class="is-active"><a>マイページ</a></li>
-        <li><a>ひとりごと投稿</a></li>
-        <li><a>ひとりごと一覧</a></li>
-        <li><a>ユーザーリスト</a></li>
-        <li><a>プロフィール編集</a></li>
-        <li><a>ログアウト</a></li>
-      </ul>
-    </div>
 
     <div class="container">
       <%= yield %>


### PR DESCRIPTION
### 概要
- CSSフレームワークのbulmaをnpmで導入しています。
- 共通のヘッダーとタブを作成しました。
- ヘッダーのリンクは別issueで対応します。

## 完成ページ
![スクリーンショット 2024-01-17 14 59 47（2）](https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/assets/90958196/252313c3-66cb-42e8-9b65-b4b1ffa3bd92)

