### PR TITLE
ログインページと会員登録ページのデザインを整える 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
       redirect_to '/users'
     else
       flash.now[:alert] = '登録に失敗しました'
-      render '/users/new'
+      render '/users/new', layout: 'header'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
       redirect_to '/users'
     else
       flash.now[:alert] = '登録に失敗しました'
-      render :new
+      render '/users/new'
     end
   end
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<section class="is-flex is-flex-direction-column is-justify-content-center is-align-items-center" style="height: calc(100vh - 3.25rem);">
+<section class="is-flex is-flex-direction-column is-justify-content-center is-align-items-center" style="height: calc(100vh - 64px);">
   <div class="box" style="width: 600px;">
     <!-- boxのタイトル -->
     <div class="content">
@@ -28,13 +28,13 @@
 
       <div class="block">
         <div class="control">
-          <%= f.submit 'ログイン', class: "button is-link has-background-light is-fullwidth" %>
+          <%= f.submit 'ログイン', class: "button is-link is-fullwidth", style: "background-color: #6a994e"%>
         </div>
       </div>
 
       <div class="block">
         <div class="control">
-          <%= link_to "会員登録がまだの方はこちら", new_user_path, class: "button is-link has-background-link is-fullwidth" %>
+          <%= link_to "会員登録がまだの方はこちら", new_user_path, class: "button is-link is-fullwidth", style: "background-color: #bc4749" %>
         </div>
       </div>
     <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,17 +1,53 @@
-<h1>ログインページ</h1>
+<section class="is-flex is-flex-direction-column is-justify-content-center is-align-items-center" style="height: calc(100vh - 3.25rem);">
+  <div class="box" style="width: 600px;">
+    <!-- boxのタイトル -->
+    <div class="content">
+      <div class="block">
+        <h2>ログイン</h2>
+        <div class="has-background-grey-lighter" style="height: 2px;"></div>
+      </div>
+    </div>
 
-<%= form_with url: login_path, local: true, data: { turbo: "false" } do |f| %>
-  <%= f.label :メールアドレス %>
-  <%= f.email_field :email %>
-  <%= f.label :パスワード %>
-  <%= f.password_field :password %>
-  <%= f.submit 'ログイン' %>
-<% end %>
+    <!-- ログインフォーム -->
+    <%= form_with url: login_path, local: true, data: { turbo: "false" } do |f| %>
+      <div class="field">
+        <label class="label">メールアドレス</label>
+        <div class="control">
+          <%= f.email_field :email, class: "input is-black", placeholder: "sample@example.com" %>
+        </div>
+      </div>
 
-<h4>
-<%= button_to "新規ユーザー登録はこちら", new_user_path, method: :get %>
-</h4>
+      <div class="block">
+        <div class="field">
+          <label class="label">パスワード</label>
+          <div class="control">
+            <%= f.password_field :password, class: "input is-black", placeholder: "********" %>
+          </div>
+        </div>
+      </div>
 
-<h4>
-<%= flash[:alert] %> 
-</h4>
+      <div class="block">
+        <div class="control">
+          <%= f.submit 'ログイン', class: "button is-link has-background-light is-fullwidth" %>
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="control">
+          <%= link_to "会員登録がまだの方はこちら", new_user_path, class: "button is-link has-background-link is-fullwidth" %>
+        </div>
+      </div>
+    <% end %>
+
+    <!-- フラッシュメッセージ -->
+    <div class="mt-5">
+      <div class="levlel">
+        <% if flash[:alert] %>
+          <div class="notification is-danger is-light has-text-centered">
+            <%= flash[:alert] %> 
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,55 @@
-<h1>新規ユーザー登録</h1>
 
+<section class="is-flex is-flex-direction-column is-justify-content-center is-align-items-center" style="height: calc(100vh - 3.25rem);">
+  <div class="box" style="width: 600px;">
+    <div class="content">
+      <div class="block">
+        <h2>会員登録</h2>
+        <div class="has-background-grey-lighter" style="height: 2px;"></div>
+      </div>
+    </div>
+
+    <%= form_with model: @user, url: users_path, data: { turbo: "false" } do |f| %>
+      <div class="field">
+        <label class="label">メールアドレス</label>
+        <div class="control">
+          <%= f.email_field :email, class: "input is-black", placeholder: "sample@example.com" %>
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="field">
+          <label class="label">パスワード</label>
+          <div class="control">
+            <%= f.password_field :password, class: "input is-black", placeholder: "********" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="control">
+          <%= f.submit '新規会員登録', class: "button is-link has-background-light is-fullwidth" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="mt-5">
+      <div class="levlel">
+        <% if flash[:alert] %>
+          <div class="notification is-danger is-light has-text-centered">
+            <%= flash[:alert] %> 
+            <% @user.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!--
 <%= form_with model: @user, url: users_path, local: true, data: { turbo: "false" } do |form| %>
-
   <div>
     <h3>
       <%= flash[:alert] %> 
@@ -27,3 +75,4 @@
     </tr>
   </table>
 <% end %>
+-->

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,4 @@
-
-<section class="is-flex is-flex-direction-column is-justify-content-center is-align-items-center" style="height: calc(100vh - 3.25rem);">
+<section class="is-flex is-flex-direction-column is-justify-content-center is-align-items-center" style="height: calc(100vh - 64px);">
   <div class="box" style="width: 600px;">
     <div class="content">
       <div class="block">
@@ -27,7 +26,7 @@
 
       <div class="block">
         <div class="control">
-          <%= f.submit '新規会員登録', class: "button is-link has-background-light is-fullwidth" %>
+          <%= f.submit '新規会員登録', class: "button is-link is-fullwidth", style: "background-color: #6a994e" %>
         </div>
       </div>
     <% end %>
@@ -46,33 +45,3 @@
     </div>
   </div>
 </section>
-
-
-<!--
-<%= form_with model: @user, url: users_path, local: true, data: { turbo: "false" } do |form| %>
-  <div>
-    <h3>
-      <%= flash[:alert] %> 
-    </h3>
-      <ul>
-      <% @user.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-
-  <table>
-    <tr>
-      <th>メールアドレス</th>
-      <td><%= form.text_field :email %></td>
-    </tr>
-    <tr>
-      <th>パスワード</th>
-      <td><%= form.text_field :password %></td>
-    </tr>
-    <tr>
-      <td><%= form.submit '送信' %></td>
-    </tr>
-  </table>
-<% end %>
--->


### PR DESCRIPTION
### 概要
- ログインページのデザインを作成しました。
- 会員登録ページのデザインを作成しました。

### 完成ページ
**＜ログインページ＞**
<img width="1440" alt="スクリーンショット 2024-01-17 17 45 33" src="https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/assets/90958196/356699ac-573d-40c5-ba43-1405492ae23f">
**＜会員登録ページ＞**
<img width="1440" alt="スクリーンショット 2024-01-17 17 47 42" src="https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/assets/90958196/d466d306-7dfa-4d31-8acd-f0ce59f6a5fd">

### 備考
以下のPRからの引き継いでいます。
https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/pull/67