### PR TITLE
ユーザーリストページのデザイン作成

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,19 +1,55 @@
-<h1>ユーザーリスト</h1>
+<main class="columns p-1 m-0">
+  <!-- メニュー -->
+  <div class="column is-one-third">
+    <div class="box">
+      <aside class="menu">
+        <div class="menu-label is-size-6 has-text-weight-semibold has-text-black">
+          <p>＜ユーザーメニュー＞</p>
+        </div>
+        <ul class="menu-list">
+          <li><a href="<%= users_path() %>">ユーザーリスト</a></li>
+          <li><a href="#">フォローリスト</a></li>
+          <li><a href="#">フォロワーリスト</a></li>
+        </ul>
+      </aside>
+    </div>
+    <div class="lavel mt-5">
+      <% if flash[:notice] %>
+        <div class="notification is-success is-light has-text-centered"><%= flash[:notice] %></div>
+      <% elsif flash[:alert] %>
+        <div class="notification is-danger is-light has-text-centered"><%= flash[:alert] %></div>
+      <% end %>
+    </div>
+  </div>
 
-<%= button_to "ユーザー登録", new_user_path, method: :get %>
-
-<% @users.each do |user| %>
-  <h3>ユーザー名</h3>
-  <span><%= user.email %></span>
-  <% if session[:user_id] == user.id %>
-    <%= button_to "ユーザー削除", user_path(user.id), method: :delete %>
-  <% end %>
-<% end %>
-
-<div class="text-notice">
-  <%= flash[:notice] %>
-</div>
-
-<div class="text-notice">
-  <%= flash[:alert] %>
-</div>
+  <!-- ユーザーリスト -->
+  <div class="column">
+    <div class="box">
+      <div class="content m-0 pl-4">
+        <h4>ユーザーリスト</h4>
+        <div class="has-background-grey-lighter" style="height: 2px;"></div>
+      </div>
+      <% @users.each do |user| %>
+      <article class="media m-1 p-0">
+        <div class="media-content">
+          <div class="columns">
+            <div class="column is-10 pl-4">
+              <div class="tags">
+                <span class="tag is-white is-size-6 has-text-weight-semibold" style="color: #386641">
+                  <p>user_name</p>
+                </span>
+                <span class="tag is-white is-size-6" style="color: #7d7d7d">
+                  <%=link_to user.email, user_path(user.id), style: "color: #7d7d7d" %></p>
+                </span>
+              </div>
+            </div>
+            <div class="column is-2 ">
+              <%= button_to "フォローする",users_path, class: "button is-small is-outlined has-text-weight-semibold mt-1", style: "color: #6a994e; border-color: #6a994e;" %>
+            </div>
+          </div>
+        </div>
+      </article>
+      <% end %>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## 概要
- 全ユーザーのアカウント名とidを表示する
- ユーザーごとにフォロー、フォロー解除ボタンを表示する（[別issueで対応予定](https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/78)）
- フォローリストボタンを選択するとフォローリストページに遷移する（[別issueで対応予定](https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/78)）
- フォロワーリストボタンを選択するとフォロワーリストページに遷移する（[別issueで対応予定](https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/78)）

### 関連issue
https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/issues/64

###  完成ページ
<img width="1552" alt="スクリーンショット 2024-01-25 15 31 20" src="https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/assets/90958196/56c62aef-3c0b-4ea9-b147-90e9fda16cfa">

