### PR TITLE
UNIXでソケット通信できるようにもろもろ対応

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,7 +22,7 @@ default: &default
 
 development:
   <<: *default
-  database: rails_development
+  database: demo
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,10 +1,7 @@
 worker_processes 4
 
-# pid "/var/run/unicorn.pid"
-# listen "/var/tmp/unicorn.sock"
-
-pid "./tmp/pids/unicorn.pid"
-listen "./tmp/sockets/unicorn.sock"
+pid "/var/run/unicorn.pid"
+listen "/var/tmp/unicorn.sock"
 
 stdout_path "./log/unicorn.stdout.log"
 stderr_path "./log/unicorn.stderr.log"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   app:
     build:
@@ -7,15 +5,13 @@ services:
       dockerfile: ./docker/rails/Dockerfile
     container_name: web_app
     # unicornを使う場合は以下を実行
-    command: bundle exec unicorn -p 3000 -c /app/config/unicorn.rb
+    command: bundle exec unicorn -p 3000 -c ./config/unicorn.rb
     # unicornを使わない場合は以下を実行
     # command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
-      - /var/tmp
+      # UnicornのUNIXソケットをnginxコンテナと共有
+      - shared_socket:/var/tmp
       - .:/app
-
-    ports:
-      - "3000:3000"
     tty: true
     stdin_open: true
   # ====RDSを使う場合は以下をコメントアウト====
@@ -30,7 +26,7 @@ services:
     ports:
       - '3308:3306'
     volumes:
-      - ./mysql-data:/var/lib/mysql
+      - mysql-data:/var/lib/mysql
       - ./sql:/usr/scripts
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -44,5 +40,12 @@ services:
     container_name: nginx
     ports:
       - '80:80'
-    volumes_from:
-      - app
+    volumes:
+      # UnicornのUNIXソケットをappコンテナと共有
+      - shared_socket:/var/tmp
+      - ./public:/var/www/html/public
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf
+
+volumes:
+    shared_socket:
+    mysql-data:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -33,8 +33,7 @@ http {
 
     # unicornへのリクエストをUnixソケット経由で転送
     upstream unicorn {
-        # server unix:/var/tmp/unicorn.sock;
-		server unix:/app/tmp/sockets/unicorn.sock;
+         server unix:/var/tmp/unicorn.sock;
     }
 
     # 仮想サーバー設定
@@ -56,7 +55,7 @@ http {
 			proxy_set_header  Host $host;
 			proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header  X-Forwarded-Proto $scheme;
-			proxy_set_header  X-Forwarded-Ssl on; # Optional
+			proxy_set_header  X-Forwarded-Ssl off; # Optional 本番環境でSSLを使う場合はonにする
 			proxy_set_header  X-Forwarded-Port $server_port;
 			proxy_set_header  X-Forwarded-Host $host;
         }

--- a/docker/rails/Dockerfile
+++ b/docker/rails/Dockerfile
@@ -11,5 +11,3 @@ ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
 RUN bundle install
 ADD . /app
-
-EXPOSE 3000

--- a/docker/rails/unicorn.rb
+++ b/docker/rails/unicorn.rb
@@ -1,7 +1,0 @@
-worker_processes 4
-
-pid "/var/run/unicorn.pid"
-listen "/var/tmp/unicorn.sock"
-
-stdout_path "./log/unicorn.stdout.log"
-stderr_path "./log/unicorn.stderr.log"


### PR DESCRIPTION
## やったこと
- すでに`./config/unicorn.rb`があるので、`docker/rails/unicorn.rb`を削除
  - これに伴い`command: bundle exec unicorn -p 3000 -c /app/config/unicorn.rb`のパスを`./config/unicorn.rb`へ修正
    - これはコンテナ内で実行されるので`/app`は不要 
- UnicornのUNIXソケットファイルをappとnginxコンテナ間で共有するためにvolumesに`shared_socket`で名前付きvolumeを追加
  - ついでにmysqlコンテナも名前付きvolumeに 
- `proxy_set_header X-Forwarded-Ssl on`だとSSL通信しようとしておかしくなる(`request.base_url`が`https://localhost`になってしまう)ので`off`に
  - ローカルだと基本`http`で`https`ではないため(本番ならonにすべき)
- バックエンドのRailsサーバーはそもそも`localhost:3000`で直接アクセスさせたくないので、3000番ポートを公開しない方がセキュア。よってポート公開設定を削除。
  - こうすることでかならずリバースプロキシ経由でアクセスされるのでシステムとして堅牢になる
- docker-composer.ymlの`version`は今はなくても良いので削除

## その他
- `database.yml`は["demo"に変更している](https://github.com/ok-os-job-change-team/kaito-twitter-clone-bootcamp/pull/111/files#diff-5a674c769541a71f2471a45c0e9dde911b4455344e3131bddc5a363701ba6325)ので、もし必要であれば調整してください 🙏 