### PR TITLE
投稿一覧画面の投稿が昇順（投稿日時の新しい順）になるように修正する

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -4,7 +4,7 @@ class TweetsController < ApplicationController
 
   # GET /tweets
   def index
-    @tweets = Tweet.all.preload(:user, :favorites)
+    @tweets = Tweet.all.preload(:user, :favorites).order(created_at: :desc)
   end
 
   # GET /tweets/:id


### PR DESCRIPTION
## 概要
投稿一覧画面の表示が投稿日時の昇順になっているので、降順になるようにする

### SQL
```
  User Load (7.4ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
  ↳ app/controllers/application_controller.rb:13:in `current_user'
  Rendering layout layouts/application.html.erb
  Rendering tweets/index.html.erb within layouts/application
  Tweet Load (1.4ms)  SELECT `tweets`.* FROM `tweets` ORDER BY `tweets`.`created_at` DESC
  ↳ app/views/tweets/index.html.erb:30
  User Load (0.7ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 2)
  ↳ app/views/tweets/index.html.erb:30
  Favorite Load (1.5ms)  SELECT `favorites`.* FROM `favorites` WHERE `favorites`.`tweet_id` IN (6, 5, 4, 3, 2, 1)
  ↳ app/views/tweets/index.html.erb:30
  ```